### PR TITLE
Bump Java version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@ limitations under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>7</javaVersion>
+    <javaVersion>8</javaVersion>
     <maven.compiler.source>1.${javaVersion}</maven.compiler.source>
     <maven.compiler.target>1.${javaVersion}</maven.compiler.target>    
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Java SE 8 is supported since 2014, and should be available on most platforms meanwhile. It provides new APIs which are benficial to Plexus, e. g. improved IO handling, etc. I'd like to start a discussion, *when* to align Plexus with Maven and make Java 8 the minimum supported version.