### PR TITLE
Remove junit4 from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,15 +334,6 @@ limitations under the License.
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Parent pom shouldn't contains dependencies. 
In child project we can use some else testing framework eg. junit5