### PR TITLE
Fix link to ASF 2.0 license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
This fixes the empty frame rendered e.g. on
https://codehaus-plexus.github.io/plexus-classworlds/licenses.html