### PR TITLE
Remove test-javadoc report and configuration improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,10 @@ limitations under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.5.0</version>
+          <configuration>
+            <quiet>true</quiet>
+            <locale>en</locale>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -639,18 +643,11 @@ limitations under the License.
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <detectLinks>true</detectLinks>
-              <links>
-                <link>http://junit.sourceforge.net/javadoc/</link>
-              </links>
-            </configuration>
             <reportSets>
               <reportSet>
                 <id>default</id>
                 <reports>
                   <report>javadoc</report>
-                  <report>test-javadoc</report>
                 </reports>
               </reportSet>
             </reportSets>


### PR DESCRIPTION
- configuration should be in one place the same for report and build
- don't detect links - in most case it is not working, and we need to maintain list of links
- remove javadoc for tests