### PR TITLE
fix site descriptor (revert partially PR #161)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@ limitations under the License.
     <connection>scm:git:https://github.com/codehaus-plexus/plexus-pom.git</connection>
     <developerConnection>${project.scm.connection}</developerConnection>
     <tag>master</tag>
-    <url>https://github.com/codehaus-plexus/plexus-pom/tree/master/</url>
+    <url>https://github.com/codehaus-plexus/plexus-pom/tree/${project.scm.tag}/</url>
   </scm>
 
   <issueManagement>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -39,6 +39,8 @@
 
   <body>
     <breadcrumbs>
+      <item name="Plexus" href="https://codehaus-plexus.github.io/"/>
+      <item name="Parent POM" href="https://codehaus-plexus.github.io/plexus-pom"/>
     </breadcrumbs>
 
     <menu name="Overview">
@@ -49,28 +51,28 @@
     <menu ref="reports" inherit="bottom" />
 
     <menu name="Plexus Projects" inherit="bottom">
-      <item name="Modello"                href="../modello/" />
-      <item name="Plexus Classworlds"     href="../plexus-classworlds/" />
+      <item name="Modello"                href="https://codehaus-plexus.github.io/modello/" />
+      <item name="Plexus Classworlds"     href="https://codehaus-plexus.github.io/plexus-classworlds/" />
       <item name="Plexus Components">
-        <item name="Plexus Archiver"      href="../plexus-archiver/"/>
-        <item name="Plexus CLI"           href="../plexus-cli/"/>
-        <item name="Plexus Compiler"      href="../plexus-compiler/"/>
-        <item name="Plexus Digest"        href="../plexus-digest/"/>
-        <item name="Plexus i18n"          href="../plexus-i18n/"/>
-        <item name="Plexus Interactivity" href="../plexus-interactivity/"/>
-        <item name="Plexus Interpolation" href="../plexus-interpolation/"/>
-        <item name="Plexus IO"            href="../plexus-io/"/>
-        <item name="Plexus Languages"     href="../plexus-languages/"/>
-        <item name="Plexus Resources"     href="../plexus-resources/"/>
-        <item name="Plexus Swizzle"       href="../plexus-swizzle/"/>
-        <item name="Plexus Velocity"      href="../plexus-velocity/"/>
+        <item name="Plexus Archiver"      href="https://codehaus-plexus.github.io/plexus-archiver/"/>
+        <item name="Plexus CLI"           href="https://codehaus-plexus.github.io/plexus-cli/"/>
+        <item name="Plexus Compiler"      href="https://codehaus-plexus.github.io/plexus-compiler/"/>
+        <item name="Plexus Digest"        href="https://codehaus-plexus.github.io/plexus-digest/"/>
+        <item name="Plexus i18n"          href="https://codehaus-plexus.github.io/plexus-i18n/"/>
+        <item name="Plexus Interactivity" href="https://codehaus-plexus.github.io/plexus-interactivity/"/>
+        <item name="Plexus Interpolation" href="https://codehaus-plexus.github.io/plexus-interpolation/"/>
+        <item name="Plexus IO"            href="https://codehaus-plexus.github.io/plexus-io/"/>
+        <item name="Plexus Languages"     href="https://codehaus-plexus.github.io/plexus-languages/"/>
+        <item name="Plexus Resources"     href="https://codehaus-plexus.github.io/plexus-resources/"/>
+        <item name="Plexus Swizzle"       href="https://codehaus-plexus.github.io/plexus-swizzle/"/>
+        <item name="Plexus Velocity"      href="https://codehaus-plexus.github.io/plexus-velocity/"/>
       </item>
       <item name="Plexus Parent POMs">
-        <item name="Plexus"               href="../plexus-pom/"/>
-        <item name="Plexus Components"    href="../plexus-components/"/>
+        <item name="Plexus"               href="https://codehaus-plexus.github.io/plexus-pom/"/>
+        <item name="Plexus Components"    href="https://codehaus-plexus.github.io/plexus-components/"/>
       </item>
-      <item name="Plexus Utils"           href="../plexus-utils/" />
-      <item name="Plexus XML"           href="../plexus-xml/" />
+      <item name="Plexus Utils"           href="https://codehaus-plexus.github.io/plexus-utils/" />
+      <item name="Plexus XML"             href="https://codehaus-plexus.github.io/plexus-xml/" />
     </menu>
   </body>
 </project>


### PR DESCRIPTION
when upgrading to this parent POM, child projects must do 2 things:
1. explicitely declare a url in their `pom.xml` (they currently usually don't have it, but just inherited default value that is now wrong)
2. override the whole breadcrumbs in their `site.xml`

= for example https://github.com/codehaus-plexus/plexus-xml/pull/18/files

understanding the why:
1. before PR #161, url was expected to be automagically inherited to child from parent value and child artifactId; This was done at the cost of parent POM inconsistency between its url and the content of site.xml, that lead to complex understanding of urls relativisation. Let's keep it simple and just declare `<url>` in each child project
2. in child projects, by default, breadcrumbs from parent will be used and additionam breadcrumb will be used: this leads to a breadcrumb to parent POM project = not something we expect. Redeclaring full breadcrumbs from the start will override content from parent

a little bit of copy paste will make things much simpler than the initial intended magic that was causing headache