### PR TITLE
Disable site descriptor publishing by child projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -660,6 +660,7 @@ limitations under the License.
             <goals>
               <goal>attach-descriptor</goal>
             </goals>
+            <inherited>false</inherited>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
- in child projects we not need publish site descriptors