### PR TITLE
Remove org.apache.maven.plugin-tools:maven-plugin-annotations from dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,12 +354,6 @@ limitations under the License.
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.maven.plugin-tools</groupId>
-        <artifactId>maven-plugin-annotations</artifactId>
-        <version>${mavenPluginToolsVersion}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${junit5Version}</version>


### PR DESCRIPTION
Similar to: https://github.com/apache/maven-apache-parent/issues/265

Only used by modello and containers: https://github.com/search?q=org%3Acodehaus-plexus+maven-plugin-annotations&type=code