### PR TITLE
Align Spotless check/apply with Maven parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -880,5 +880,27 @@ limitations under the License.
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>format-check</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+        </property>
+      </activation>
+      <properties>
+        <spotless.action>check</spotless.action>
+      </properties>
+    </profile>
+    <profile>
+      <id>format</id>
+      <activation>
+        <property>
+          <name>!env.CI</name>
+        </property>
+      </activation>
+      <properties>
+        <spotless.action>apply</spotless.action>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Builds should either apply spotless or check for it depending on whether it is running in CI or not.

Detected in the course of support-and-care/maven-support-and-care#77 and codehaus-plexus/.github#45